### PR TITLE
Add settings feature to edit lookup_context records in BroadcastDashBoard

### DIFF
--- a/cypress/e2e/settings-modal.cy.ts
+++ b/cypress/e2e/settings-modal.cy.ts
@@ -1,0 +1,73 @@
+describe('Settings Modal', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/broadcasts', {
+      fixture: 'broadcasts.json'
+    }).as('broadcasts')
+
+    cy.intercept('GET', '**/lookup_context?*', {
+      statusCode: 200,
+      body: [
+        { name: 'comment_summary_prompt', content: 'Test comment summary' },
+        { name: 'impact_summary_prompt', content: 'Test impact summary' },
+        { name: 'message_summary_prompt', content: 'Test message summary' }
+      ]
+    }).as('lookupContext')
+
+    cy.intercept('PATCH', '**/lookup_context', {
+      statusCode: 200
+    }).as('updateLookupContext')
+
+    cy.visit('/')
+    cy.wait('@broadcasts')
+  })
+
+  it('opens settings modal when clicking settings button', () => {
+    cy.contains('button', 'Settings').click()
+    cy.contains('Edit Settings').should('be.visible')
+    cy.contains('Comment Summary Prompt').should('be.visible')
+    cy.contains('Impact Summary Prompt').should('be.visible')
+    cy.contains('Message Summary Prompt').should('be.visible')
+  })
+
+  it('loads existing settings from lookup_context table', () => {
+    cy.contains('button', 'Settings').click()
+    cy.wait('@lookupContext')
+    
+    cy.get('textarea').should('have.length', 3)
+    cy.contains('textarea', 'Test comment summary').should('exist')
+    cy.contains('textarea', 'Test impact summary').should('exist')
+    cy.contains('textarea', 'Test message summary').should('exist')
+  })
+
+  it('can update settings', () => {
+    cy.contains('button', 'Settings').click()
+    cy.wait('@lookupContext')
+
+    // Update the first textarea
+    cy.get('textarea').first()
+      .clear()
+      .type('Updated comment summary')
+
+    cy.contains('button', 'Save').click()
+    cy.wait('@updateLookupContext')
+
+    // Modal should close after saving
+    cy.contains('Edit Settings').should('not.exist')
+  })
+
+  it('can cancel without saving changes', () => {
+    cy.contains('button', 'Settings').click()
+    cy.wait('@lookupContext')
+
+    // Make some changes
+    cy.get('textarea').first()
+      .clear()
+      .type('Unsaved changes')
+
+    cy.contains('button', 'Cancel').click()
+
+    // Modal should close without saving
+    cy.contains('Edit Settings').should('not.exist')
+    cy.get('@updateLookupContext.all').should('have.length', 0)
+  })
+})

--- a/src/components/broadcaster/BroadcastDashBoard.tsx
+++ b/src/components/broadcaster/BroadcastDashBoard.tsx
@@ -3,6 +3,7 @@ import DateUtils from 'utils/date'
 import { useBroadcastDashboardQuery, useUpdateBroadcast } from 'hooks/broadcast'
 import PastBroadcasts from './PastBroadcasts'
 import RunAtPicker from './RunAtPicker'
+import SettingsModal from './SettingsModal'
 import { useQueryClient } from '@tanstack/react-query'
 import LastBroadcastStatus from './LastBroadcastStatus'
 import { sendNowBroadcast } from '../../apis/broadcastApi'
@@ -14,6 +15,7 @@ const BroadcastDashboard = () => {
   const { data, isPending, error } = useBroadcastDashboardQuery(queryClient)
   const [isRunAtPickerOpen, setIsRunAtPickerOpen] = useState(false)
   const [isSent, setIsSent] = useState<boolean>(false)
+  const [showSettingsModal, setShowSettingsModal] = useState(false)
 
   const { mutate } = useUpdateBroadcast(queryClient)
 
@@ -236,6 +238,16 @@ const BroadcastDashboard = () => {
       <hr className='mt-8 border-gray-500' />
 
       <PastBroadcasts />
+
+      <button
+        type='button'
+        className='fixed bottom-4 right-4 bg-blue-500 text-white p-2 rounded hover:bg-blue-600'
+        onClick={() => setShowSettingsModal(true)}
+      >
+        Settings
+      </button>
+
+      {showSettingsModal && <SettingsModal onClose={() => setShowSettingsModal(false)} />}
     </div>
   )
 }

--- a/src/components/broadcaster/SettingsModal.tsx
+++ b/src/components/broadcaster/SettingsModal.tsx
@@ -1,0 +1,128 @@
+import React, { useState, useEffect } from 'react';
+import { supabase } from '../../utils/supabaseClient';
+
+interface SettingsModalProps {
+  onClose: () => void;
+}
+
+const SettingsModal: React.FC<SettingsModalProps> = ({ onClose }) => {
+  const [commentSummary, setCommentSummary] = useState('');
+  const [impactSummary, setImpactSummary] = useState('');
+  const [messageSummary, setMessageSummary] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      const { data, error } = await supabase
+        .from('lookup_context')
+        .select('name, content')
+        .in('name', ['comment_summary_prompt', 'impact_summary_prompt', 'message_summary_prompt']);
+
+      if (!error && data) {
+        data.forEach(item => {
+          switch (item.name) {
+            case 'comment_summary_prompt':
+              setCommentSummary(item.content);
+              break;
+            case 'impact_summary_prompt':
+              setImpactSummary(item.content);
+              break;
+            case 'message_summary_prompt':
+              setMessageSummary(item.content);
+              break;
+          }
+        });
+      }
+      setIsLoading(false);
+    };
+
+    void fetchSettings();
+  }, []);
+
+  const handleSave = async () => {
+    setIsLoading(true);
+    const updates = [
+      { name: 'comment_summary_prompt', content: commentSummary },
+      { name: 'impact_summary_prompt', content: impactSummary },
+      { name: 'message_summary_prompt', content: messageSummary }
+    ];
+
+    for (const update of updates) {
+      await supabase
+        .from('lookup_context')
+        .update({ content: update.content })
+        .eq('name', update.name);
+    }
+
+    setIsLoading(false);
+    onClose();
+  };
+
+  if (isLoading) {
+    return (
+      <div className='fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center'>
+        <div className='bg-white p-4 rounded'>
+          <p>Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center'>
+      <div className='bg-white p-4 rounded max-w-lg w-full mx-4'>
+        <h3 className='text-lg font-medium mb-4'>Edit Settings</h3>
+        <div className='space-y-4'>
+          <div>
+            <label className='block text-sm font-medium text-gray-700 mb-1'>
+              Comment Summary Prompt
+            </label>
+            <textarea
+              value={commentSummary}
+              onChange={(e) => setCommentSummary(e.target.value)}
+              className='block w-full p-2 border rounded h-24'
+            />
+          </div>
+          <div>
+            <label className='block text-sm font-medium text-gray-700 mb-1'>
+              Impact Summary Prompt
+            </label>
+            <textarea
+              value={impactSummary}
+              onChange={(e) => setImpactSummary(e.target.value)}
+              className='block w-full p-2 border rounded h-24'
+            />
+          </div>
+          <div>
+            <label className='block text-sm font-medium text-gray-700 mb-1'>
+              Message Summary Prompt
+            </label>
+            <textarea
+              value={messageSummary}
+              onChange={(e) => setMessageSummary(e.target.value)}
+              className='block w-full p-2 border rounded h-24'
+            />
+          </div>
+        </div>
+        <div className='mt-4 flex justify-end space-x-2'>
+          <button
+            onClick={handleSave}
+            className='bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600'
+            disabled={isLoading}
+          >
+            Save
+          </button>
+          <button
+            onClick={onClose}
+            className='bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600'
+            disabled={isLoading}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsModal;


### PR DESCRIPTION
Introduced a new `SettingsModal` component allowing users to edit specific records in the `lookup_context` table. Integrated a settings button in the `BroadcastDashBoard` that opens this modal. Added Cypress tests to verify the modal opens correctly, loads current settings, and saves changes effectively. Ensured that changes do not persist if canceled. This enhancement improves user interaction by simplifying settings management directly from the dashboard.

Created with `SOLV_R`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a settings modal in the Broadcast Dashboard for managing user settings.
	- Added a button to open the settings modal, enhancing user accessibility.
	- Implemented functionality to fetch and update settings within the modal.

- **Tests**
	- Established a comprehensive suite of end-to-end tests for the settings modal to ensure expected behavior and user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->