### PR TITLE
Dashboard page should refresh every 60s

### DIFF
--- a/src/hooks/broadcast.ts
+++ b/src/hooks/broadcast.ts
@@ -20,6 +20,7 @@ const useBroadcastDashboardQuery = (queryClient: QueryClient) =>
   useQuery({
     queryKey: ['broadcastDashboard'],
     queryFn: getBroadcastDashboard,
+    staleTime: 60 * 1000,
     structuralSharing: (
       oldData: AxiosResponse<BroadcastDashboard> | undefined,
       newData: AxiosResponse<BroadcastDashboard>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced broadcast query functionality for improved data management.
	- Introduced a `staleTime` property for the broadcast dashboard query, ensuring data freshness for 60 seconds.
	- Updated conditions for refreshing past broadcasts based on new data.

- **Bug Fixes**
	- Improved synchronization between the broadcast dashboard and past broadcasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->