### PR TITLE
Implement UI to Update Number of Recipients for next broadcast

### DIFF
--- a/src/apis/broadcasts.ts
+++ b/src/apis/broadcasts.ts
@@ -39,13 +39,15 @@ export const updateBroadcast = async ({
   id,
   firstMessage,
   secondMessage,
-  runAt
+  runAt,
+  noRecipients
 }: Partial<UpcomingBroadcast>): Promise<UpcomingBroadcast> =>
   axios.patch(BROADCAST_SIDEBAR, {
     id,
     firstMessage,
     secondMessage,
-    runAt
+    runAt,
+    noRecipients
   });
 
 export const sendNowBroadcast = async (): Promise<void> => axios.get(SEND_NOW);

--- a/src/components/EditNumberOfRecipientsDialog.test.tsx
+++ b/src/components/EditNumberOfRecipientsDialog.test.tsx
@@ -1,0 +1,178 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import EditNumberOfRecipientsDialog from './EditNumberOfRecipientsDialog';
+
+import { useToast } from '@/hooks/use-toast';
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: vi.fn(() => ({
+    toast: vi.fn(() => ({
+      id: '1',
+      dismiss: vi.fn(),
+      update: vi.fn()
+    })),
+    dismiss: vi.fn(),
+    toasts: []
+  }))
+}));
+describe('EditNumberOfRecipientsDialog', () => {
+  const defaultProps = {
+    title: 'Edit Recipients',
+    noRecipients: 50,
+    onSave: vi.fn()
+  };
+
+  it('renders initial number of recipients', () => {
+    render(<EditNumberOfRecipientsDialog {...defaultProps} />);
+    expect(screen.getByText('50 recipients')).toBeInTheDocument();
+  });
+
+  it('opens dialog when trigger is clicked', async () => {
+    render(<EditNumberOfRecipientsDialog {...defaultProps} />);
+    fireEvent.click(screen.getByText('50 recipients'));
+
+    const dialog = await screen.findByRole('dialog');
+    const withinDialog = within(dialog);
+
+    expect(withinDialog.getByRole('heading', {
+      name: 'Edit Recipients'
+    })).toBeInTheDocument();
+
+    expect(withinDialog.getByText(
+      'Set the number of recipients for the next batch.'
+    )).toBeInTheDocument();
+
+    expect(withinDialog.getByText('Recipients')).toBeInTheDocument();
+    expect(withinDialog.getByRole('spinbutton')).toBeInTheDocument();
+    expect(withinDialog.getByRole('button', {
+      name: 'Cancel'
+    })).toBeInTheDocument();
+    expect(withinDialog.getByRole('button', {
+      name: 'Save changes'
+    })).toBeInTheDocument();
+  });
+
+  it('shows validation error for invalid input', async () => {
+    render(<EditNumberOfRecipientsDialog {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('50 recipients'));
+
+    const dialog = await screen.findByRole('dialog');
+    const withinDialog = within(dialog);
+
+    const input = withinDialog.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '0' } });
+    fireEvent.blur(input);
+
+    const submitButton = withinDialog.getByRole('button', {
+      name: 'Save changes'
+    });
+    fireEvent.click(submitButton);
+
+    expect(await withinDialog.findByText('Recipient count must be at least 1'))
+      .toBeInTheDocument();
+  });
+
+  it('shows validation error for exceeding maximum', async () => {
+    render(<EditNumberOfRecipientsDialog {...defaultProps} />);
+    fireEvent.click(screen.getByText('50 recipients'));
+
+    const dialog = await screen.findByRole('dialog');
+    const withinDialog = within(dialog);
+
+    const input = withinDialog.getByRole('spinbutton');
+    expect(input).toHaveValue(50);
+
+    fireEvent.change(input, { target: { value: '200000' } });
+    fireEvent.blur(input);
+
+    const submitButton = withinDialog.getByRole('button', {
+      name: 'Save changes'
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(withinDialog.getByText('Recipient count cannot exceed 100,000'))
+        .toBeInTheDocument();
+    });
+
+    expect(defaultProps.onSave).not.toHaveBeenCalled();
+  });
+
+  it('calls onSave with new value when form is submitted', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<EditNumberOfRecipientsDialog {...defaultProps} onSave={onSave} />);
+    fireEvent.click(screen.getByText('50 recipients'));
+
+    const dialog = await screen.findByRole('dialog');
+    const withinDialog = within(dialog);
+
+    const input = withinDialog.getByRole('spinbutton');
+    expect(input).toHaveValue(50);
+
+    fireEvent.change(input, { target: { value: '75' } });
+    expect(input).toHaveValue(75);
+
+    const submitButton = withinDialog.getByRole('button', {
+      name: 'Save changes'
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(75);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows error toast when save fails', async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error('Save failed'));
+    const toastFn = vi.fn();
+
+    vi.mocked(useToast).mockImplementation(() => ({
+      toast: toastFn,
+      dismiss: vi.fn(),
+      toasts: []
+    }));
+
+    render(<EditNumberOfRecipientsDialog {...defaultProps} onSave={onSave} />);
+
+    fireEvent.click(screen.getByText('50 recipients'));
+
+    const dialog = await screen.findByRole('dialog');
+    const withinDialog = within(dialog);
+
+    const submitButton = withinDialog.getByRole('button', {
+      name: 'Save changes'
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(toastFn).toHaveBeenCalledWith({
+        title: 'Error',
+        description: 'Could not update recipient count. Please try again!'
+      });
+    });
+
+    expect(dialog).toBeInTheDocument();
+  });
+
+  it('closes dialog when cancel is clicked', async () => {
+    render(<EditNumberOfRecipientsDialog {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('50 recipients'));
+
+    const dialog = await screen.findByRole('dialog');
+    const cancelButton = within(dialog).getByRole('button', {
+      name: 'Cancel'
+    });
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/EditNumberOfRecipientsDialog.tsx
+++ b/src/components/EditNumberOfRecipientsDialog.tsx
@@ -1,0 +1,134 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Users } from 'lucide-react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input.tsx';
+import { useToast } from '@/hooks/use-toast';
+
+const formSchema = z.object({
+  noRecipients: z.coerce
+    .number()
+    .int()
+    .min(1, 'Recipient count must be at least 1')
+    .max(100_000, 'Recipient count cannot exceed 100,000')
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+interface EditNumberOfRecipientsDialogProps {
+  title: string;
+  noRecipients: number;
+  onSave: (noRecipients: number) => Promise<void> | void;
+}
+
+const EditNumberOfRecipientsDialog = ({
+  title,
+  noRecipients,
+  onSave
+}: EditNumberOfRecipientsDialogProps) => {
+  const [open, setOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const { toast } = useToast();
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      noRecipients
+    }
+  });
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      setIsSaving(true);
+      await onSave(data.noRecipients);
+      form.reset({ noRecipients: data.noRecipients });
+      setOpen(false);
+    } catch {
+      toast({
+        title: 'Error',
+        description: 'Could not update recipient count. Please try again!'
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <div
+          className="flex items-center gap-2 p-2 w-full whitespace-pre-wrap rounded-md border border-input bg-background px-3 py-2 text-sm cursor-pointer hover:bg-accent/50 transition-colors dark:bg-[#1E1E1E] dark:border-neutral-600 dark:hover:bg-neutral-800">
+          <Users className="h-4 w-4" />
+          <span className="text-sm">
+            {noRecipients} recipients
+            </span>
+        </div>
+      </DialogTrigger>
+      <DialogContent
+        className="h-svh w-svw max-w-none rounded-none overflow-y-scroll bg-background border border-input dark:bg-[#1E1E1E] dark:border-neutral-700">
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <DialogHeader>
+            <DialogTitle className="text-base">{title}</DialogTitle>
+            <DialogDescription className="text-muted-foreground dark:text-neutral-400">
+              Set the number of recipients for the next batch.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="flex items-center gap-4">
+              <label htmlFor="recipientCount" className="text-right dark:text-neutral-400">
+                Recipients
+              </label>
+              <Input
+                id="recipientCount"
+                type="number"
+                {...form.register('noRecipients')}
+                className="bg-background dark:bg-[#1E1E1E] border-input"
+              />
+            </div>
+            {form.formState.errors.noRecipients && (
+              <span className="text-sm text-red-500">
+                {form.formState.errors.noRecipients.message}
+              </span>
+            )}
+          </div>
+          <DialogFooter className="gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1 bg-input hover:bg-input/50 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+              onClick={() => {
+                form.reset({ noRecipients });
+                setOpen(false);
+              }}
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              className="flex-1 bg-[#2F80ED] hover:bg-[#2D7BE5] text-white"
+              disabled={isSaving}
+            >
+              {isSaving ? 'Saving...' : 'Save changes'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default EditNumberOfRecipientsDialog;

--- a/src/components/NextBatchSection.tsx
+++ b/src/components/NextBatchSection.tsx
@@ -1,14 +1,15 @@
-import { CalendarClockIcon, Users } from 'lucide-react';
+import { CalendarClockIcon } from 'lucide-react';
 
 import { sendNowBroadcast, UpcomingBroadcast } from '@/apis/broadcasts';
 import BroadcastCard from '@/components/BroadcastCard';
 import EditConversationMessageDialog from '@/components/EditConversationMessageDialog';
+import EditNumberOfRecipientsDialog from '@/components/EditNumberOfRecipientsDialog.tsx';
 import PauseScheduleDialog from '@/components/PauseScheduleDialog';
 import { SendNowDialog } from '@/components/SendNowDialog';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   useBroadcastMutation,
-  useBroadcastsQuery,
+  useBroadcastsQuery
 } from '@/hooks/useBroadcastsQuery';
 import { formatDateTime } from '@/lib/date';
 
@@ -35,7 +36,7 @@ const NextBatchSection = () => {
   }
 
   const updateBroadcast = async (
-    data: Partial<UpcomingBroadcast>,
+    data: Partial<UpcomingBroadcast>
   ): Promise<void> => {
     await broadcastMutation.mutateAsync(data);
   };
@@ -48,22 +49,25 @@ const NextBatchSection = () => {
             Scheduled for{' '}
             {formatDateTime(
               new Date(broadcastsQuery.data!.upcoming.runAt * 1000),
-              Intl.DateTimeFormat().resolvedOptions().timeZone,
+              Intl.DateTimeFormat().resolvedOptions().timeZone
             )}
           </div>
-          <div className="flex items-center gap-2 p-2 w-full whitespace-pre-wrap rounded-md border border-input bg-background px-3 py-2 text-sm cursor-pointer hover:bg-accent/50 transition-colors dark:bg-[#1E1E1E] dark:border-neutral-600 dark:hover:bg-neutral-800">
-            <Users className="h-4 w-4" />
-            <span className="text-sm">
-              {broadcastsQuery.data?.upcoming.noRecipients.toLocaleString()}{' '}
-              recipients
-            </span>
-          </div>
+          <EditNumberOfRecipientsDialog
+            noRecipients={broadcastsQuery.data!.upcoming.noRecipients || 0}
+            title="Edit Recipient Count"
+            onSave={(newNoRecipients) =>
+              updateBroadcast({
+                id: broadcastsQuery.data?.upcoming.id,
+                noRecipients: newNoRecipients
+              })
+            }
+          />
           <div className="flex gap-2">
             <PauseScheduleDialog
               onConfirm={(runAt) =>
                 updateBroadcast({
                   id: broadcastsQuery.data?.upcoming.id,
-                  runAt,
+                  runAt
                 })
               }
               currentDate={
@@ -84,7 +88,7 @@ const NextBatchSection = () => {
               onSave={(newMessage) =>
                 updateBroadcast({
                   id: broadcastsQuery.data?.upcoming.id,
-                  firstMessage: newMessage,
+                  firstMessage: newMessage
                 })
               }
             />
@@ -99,7 +103,7 @@ const NextBatchSection = () => {
               onSave={(newMessage) =>
                 updateBroadcast({
                   id: broadcastsQuery.data?.upcoming.id,
-                  secondMessage: newMessage,
+                  secondMessage: newMessage
                 })
               }
             />

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }


### PR DESCRIPTION
Co-authored-by: Thuan Ngo <thuan.ngo@eastagile.com>

[OUT-308](https://linear.app/pdw/issue/OUT-308/implement-ui-to-update-number-of-recipients-for-next-broadcast)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new, user-friendly dialog for editing the number of recipients. The dialog includes clear input validation (allowing values from 1 to 100,000), real-time error notifications, and seamless save/cancel interactions.
  - Enhanced broadcast updates to support adjustments for recipient counts directly.
  - Added a new, consistently styled input component to improve form interactions.

- **Tests**
  - Implemented a comprehensive test suite ensuring reliable dialog behavior, including rendering, user interactions, validation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->