### PR TITLE
In conversation summary sidebar, hide the "Reporters contacted:" label if there is none

### DIFF
--- a/src/convo-sidebar/pages/Home/index.tsx
+++ b/src/convo-sidebar/pages/Home/index.tsx
@@ -216,11 +216,13 @@ function Home() {
             {(updateError as ApiResponseError).response?.data.type === 'zipcode' ? (updateError as ApiResponseError).response?.data.msg : ''}
           </div> : null}
 
-        <div className="pt-2">
-          Reporters contacted:{' '}
-          <span className="font-bold">{conversation.assignee_user_name.join(', ')}</span>
-        </div>
-        <div className="flex flex-wrap gap-2">
+        {conversation.assignee_user_name.length > 0 && (
+          <div className="pt-2">
+            Reporters contacted:{' '}
+            <span className="font-bold">{conversation.assignee_user_name.join(', ')}</span>
+          </div>
+        )}
+        <div className="flex flex-wrap gap-2 pt-2">
           {keywordLabels.map(tag => (
             <div key={tag} className="rounded-missive-border-radius bg-missive-text-color-d px-2 py-2 font-bold">
               {tag}


### PR DESCRIPTION
Co-authored-by: Thuan Ngo <thuan.ngo@eastagile.com>

[OUT-304](https://linear.app/pdw/issue/OUT-304/in-conversation-summary-sidebar-hide-the-reporters-contacted-label-if)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The interface now conditionally displays the "Reporters contacted" section only when reporter information is available, ensuring users see relevant content.
- **Style**
	- Improved layout formatting for a cleaner and more consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->