### PR TITLE
[f] - Log user out when 401 error

### DIFF
--- a/src/convo-sidebar/components/PrivateRoute.tsx
+++ b/src/convo-sidebar/components/PrivateRoute.tsx
@@ -7,7 +7,7 @@ import { LOGIN_PATH } from '../constants/routes';
 import { useToken, useTokenChanged } from '../providers/auth';
 
 interface PrivateRouteProps {
-  children: ReactNode
+  children: ReactNode;
 }
 
 const PrivateRoute = ({ children }: PrivateRouteProps) => {
@@ -18,8 +18,9 @@ const PrivateRoute = ({ children }: PrivateRouteProps) => {
   const location = useLocation();
 
   const saveLocationAndNavigateToLogin = () => {
-    const queryParams = new URLSearchParams({ next: location.pathname }).toString();
-    console.log(queryParams);
+    const queryParams = new URLSearchParams({
+      next: location.pathname,
+  }).toString();
 
     navigate(`${LOGIN_PATH}?${queryParams}`);
   };
@@ -55,7 +56,7 @@ const PrivateRoute = ({ children }: PrivateRouteProps) => {
 };
 
 PrivateRoute.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
 };
 
 export default PrivateRoute;

--- a/src/convo-sidebar/lib/axios.ts
+++ b/src/convo-sidebar/lib/axios.ts
@@ -9,8 +9,9 @@ axios.interceptors.response.use(
   (response: AxiosResponse) => response,
   async (error: AxiosError) => {
     if (error.response?.status === 401 || error.response?.status === 403) {
+      console.log("===== Error 401, reloading")
       localStorage.removeItem('token')
-      window.location.reload();
+      Missive.reload();
     }
     return Promise.reject(error);
   }

--- a/src/convo-sidebar/lib/axios.ts
+++ b/src/convo-sidebar/lib/axios.ts
@@ -9,7 +9,6 @@ axios.interceptors.response.use(
   (response: AxiosResponse) => response,
   async (error: AxiosError) => {
     if (error.response?.status === 401 || error.response?.status === 403) {
-      console.log("===== Error 401, reloading")
       localStorage.removeItem('token')
       Missive.reload();
     }

--- a/src/convo-sidebar/lib/axios.ts
+++ b/src/convo-sidebar/lib/axios.ts
@@ -1,6 +1,5 @@
 import type { AxiosError, AxiosResponse } from 'axios';
 import Axios from 'axios'
-import { LOGOUT_PATH } from '../constants/routes'
 
 const axios = Axios.create({
   baseURL: import.meta.env.VITE_BASE_URL as string
@@ -10,8 +9,8 @@ axios.interceptors.response.use(
   (response: AxiosResponse) => response,
   async (error: AxiosError) => {
     if (error.response?.status === 401 || error.response?.status === 403) {
-      // HashRouter due to hosting on S3
-      window.location.href = `#${LOGOUT_PATH}`;
+      localStorage.removeItem('token')
+      window.location.reload();
     }
     return Promise.reject(error);
   }

--- a/src/convo-sidebar/lib/missive.d.ts
+++ b/src/convo-sidebar/lib/missive.d.ts
@@ -58,6 +58,8 @@ declare class MissiveClass {
   public async fetchConversations(ids: string[]): Promise<Conversation[]>
 
   public async fetchLabels(): Promise<Label[]>
+
+  public reload(): void;
 }
 
 declare const Missive: InstanceType<typeof MissiveClass>

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -8,8 +8,8 @@ axios.interceptors.response.use(
   (response: AxiosResponse) => response,
   async (error: AxiosError) => {
     if (error.response?.status === 401 || error.response?.status === 403) {
-      console.log("===== Error 401, reloading")
-      localStorage.removeItem('token')
+      console.log('===== Error 401, reloading');
+      localStorage.removeItem('token');
       Missive.reload();
 }
     return Promise.reject(error);

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -11,7 +11,7 @@ axios.interceptors.response.use(
       console.log('===== Error 401, reloading');
       localStorage.removeItem('token');
       Missive.reload();
-}
+    }
     return Promise.reject(error);
   }
 );

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -4,11 +4,10 @@ const instance = axios.create({
   baseURL: import.meta.env.VITE_BACKEND_BASE_URL
 });
 
-axios.interceptors.response.use(
+instance.interceptors.response.use(
   (response: AxiosResponse) => response,
   async (error: AxiosError) => {
     if (error.response?.status === 401 || error.response?.status === 403) {
-      console.log('===== Error 401, reloading');
       localStorage.removeItem('token');
       Missive.reload();
     }

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -8,9 +8,10 @@ axios.interceptors.response.use(
   (response: AxiosResponse) => response,
   async (error: AxiosError) => {
     if (error.response?.status === 401 || error.response?.status === 403) {
-      localStorage.removeItem('token');
-      window.location.reload();
-    }
+      console.log("===== Error 401, reloading")
+      localStorage.removeItem('token')
+      Missive.reload();
+}
     return Promise.reject(error);
   }
 );

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,7 +1,18 @@
-import axios from 'axios';
+import axios, { AxiosError, AxiosResponse } from 'axios';
 
 const instance = axios.create({
   baseURL: import.meta.env.VITE_BACKEND_BASE_URL
 });
+
+axios.interceptors.response.use(
+  (response: AxiosResponse) => response,
+  async (error: AxiosError) => {
+    if (error.response?.status === 401 || error.response?.status === 403) {
+      localStorage.removeItem('token');
+      window.location.reload();
+    }
+    return Promise.reject(error);
+  }
+);
 
 export default instance;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Handle 401/403 errors by logging out user and reloading app in Axios interceptors and `PrivateRoute`.
> 
>   - **Behavior**:
>     - On 401 or 403 error, remove `token` from `localStorage` and call `Missive.reload()` in `axios.ts` and `src/lib/axios.ts`.
>     - In `PrivateRoute.tsx`, navigate to login if token is invalid or expired.
>   - **Missive Class**:
>     - Add `reload()` method to `MissiveClass` in `missive.d.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PublicDataWorks%2Ftxt-outlier-frontend&utm_source=github&utm_medium=referral)<sup> for f5b3ad53d1e8729e0384d98e898339083286d68b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->