### PR TITLE
[f] - Add stats for old campaigns

### DIFF
--- a/src/apis/campaigns.ts
+++ b/src/apis/campaigns.ts
@@ -19,6 +19,11 @@ export interface Campaign {
   delay: number;
   recipientCount: number;
   runAt: number;
+  firstMessageCount: number;
+  secondMessageCount: number;
+  successfulDeliveries: number;
+  failedDeliveries: number;
+  unsubscribes: number;
 }
 
 export interface Pagination {

--- a/src/pages/campaign/CampaignHistory.tsx
+++ b/src/pages/campaign/CampaignHistory.tsx
@@ -175,6 +175,45 @@ const CampaignHistory = () => {
                           </p>
                         </div>
                       )}
+
+                      <div className="bg-muted p-3 rounded-md">
+                        <h4 className="text-sm font-medium mb-2">
+                          Response breakdown:
+                        </h4>
+                        <div className="grid grid-cols-2 gap-4 text-sm">
+                          <div>
+                            <p className="font-medium">
+                              Conversation starters sent:
+                            </p>
+                            {campaign.firstMessageCount}
+                          </div>
+                          {campaign.secondMessage && (
+                            <div>
+                              <p className="font-medium">
+                                Second Message Count:
+                              </p>
+                              {campaign.secondMessageCount}
+                            </div>
+                          )}
+                          <div>
+                            <p className="font-medium">
+                              Delivered successfully:
+                            </p>
+                            {campaign.successfulDeliveries}
+                          </div>
+                          <div>
+                            <p className="font-medium">Failed to deliver:</p>
+                            {campaign.failedDeliveries}
+                          </div>
+
+                          <div>
+                            <p className="font-medium">
+                              Unsubscribed:
+                            </p>
+                            {campaign.unsubscribes}
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   )}
                 </CardContent>


### PR DESCRIPTION
## Description
This Pull Request introduces enhancements to the campaign management feature in our application. Specifically, it extends the campaign data model to include detailed metrics about message counts and delivery outcomes, and updates the Campaign History page to display these metrics, providing users with a comprehensive view of their campaign performance.

## Summary of Changes
1. **Campaign Data Model Enhancements**:
   - Added new fields to the `Campaign` interface: `firstMessageCount`, `secondMessageCount`, `successfulDeliveries`, `failedDeliveries`, and `unsubscribes`.

2. **Campaign History Page Updates**:
   - Implemented a new section in the `CampaignHistory.tsx` component to display a breakdown of response metrics.
   - Added UI elements to show:
     - The number of conversation starters sent (`firstMessageCount`).
     - The count of second messages sent, if applicable (`secondMessageCount`).
     - The number of successfully delivered messages (`successfulDeliveries`).
     - The number of failed deliveries (`failedDeliveries`).
     - The number of recipients who unsubscribed (`unsubscribes`).
