### PR TITLE
Fix date selection in PauseScheduleDialog test

### DIFF
--- a/src/pages/broadcast/ReScheduleDialog.test.tsx
+++ b/src/pages/broadcast/ReScheduleDialog.test.tsx
@@ -111,8 +111,10 @@ describe('PauseScheduleDialog', () => {
     fireEvent.click(screen.getByText('Reschedule'));
 
     // Select a different date
-    fireEvent.click(screen.getByText(targetDate.getDate().toString()));
-
+    const dateButtons = screen.getAllByText(targetDate.getDate().toString());
+    const activeButton = dateButtons.find(button => !button.hasAttribute('disabled'));
+    fireEvent.click(activeButton!);
+    
     // Click confirm button in dialog
     fireEvent.click(
       await within(await screen.findByRole('dialog')).findByRole('button', {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved the reliability of scheduling dialog tests by ensuring that date selections target only active options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->