### PR TITLE
Display labels in new line

### DIFF
--- a/src/pages/campaign/CampaignHistory.tsx
+++ b/src/pages/campaign/CampaignHistory.tsx
@@ -180,14 +180,14 @@ const CampaignHistory = () => {
                       <p className="text-sm text-muted-foreground">
                         {unixTimestampInSecondToDate(campaign.runAt)}
                         {campaign.campaignLabelNames && campaign.campaignLabelNames.length > 0 && (
-                          <span className="ml-2 inline-flex items-center flex-wrap gap-1">
+                          <div className="w-full mt-1 flex">
                             {campaign.campaignLabelNames.map((labelName, idx) => (
-                              <span key={idx} className="inline-flex items-center bg-muted rounded px-1.5 py-0.5 text-xs">
+                              <span key={idx} className="mr-1 mb-1 inline-flex items-center bg-muted rounded px-1.5 py-0.5 text-xs">
                                 <Tag className="h-3 w-3 mr-1" />
                                 {labelName}
                               </span>
                             ))}
-                          </span>
+                          </div>
                         )}
                       </p>
                       <p className="text-sm text-ellipsis overflow-hidden whitespace-nowrap">

--- a/src/pages/campaign/UpcomingCampaigns.tsx
+++ b/src/pages/campaign/UpcomingCampaigns.tsx
@@ -436,14 +436,14 @@ export default function UpcomingCampaigns() {
                               'h:mm a',
                             )}
                             {editedCampaign.campaignLabelNames && editedCampaign.campaignLabelNames.length > 0 && (
-                              <>
+                              <div className="w-full mt-1 flex">
                                 {editedCampaign.campaignLabelNames.map((labelName, idx) => (
-                                  <span key={idx} className="ml-2 inline-flex items-center bg-muted rounded px-1.5 py-0.5 text-xs">
+                                  <span key={idx} className="mr-1 mb-1 inline-flex items-center bg-muted rounded px-1.5 py-0.5 text-xs">
                                     <Tag className="h-3 w-3 mr-1" />
                                     {labelName}
                                   </span>
                                 ))}
-                              </>
+                              </div>
                             )}
                           </div>
                           <div className="mt-1 flex flex-wrap">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change campaign labels to display on a new line in `CampaignHistory.tsx` and `UpcomingCampaigns.tsx`.
> 
>   - **Layout Changes**:
>     - In `CampaignHistory.tsx`, change campaign labels from `span` to `div` to display labels on a new line.
>     - In `UpcomingCampaigns.tsx`, change campaign labels from `span` to `div` for new line display.
>   - **CSS Adjustments**:
>     - Adjust CSS classes in both files to ensure proper spacing and alignment of labels.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PublicDataWorks%2Ftxt-outlier-frontend&utm_source=github&utm_medium=referral)<sup> for 1ac18a453556c4d3950265be8108fd5e8a14ff20. You can [customize](https://app.ellipsis.dev/PublicDataWorks/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the layout and spacing of campaign label tags in both the campaign history and upcoming campaigns sections for a more consistent and visually appealing display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->