### PR TITLE
Fix segment since condition to properly handle null/undefined values

### DIFF
--- a/src/pages/campaign/UpcomingCampaigns.tsx
+++ b/src/pages/campaign/UpcomingCampaigns.tsx
@@ -268,7 +268,7 @@ export default function UpcomingCampaigns() {
           )}
         >
           {segmentName}
-          {segment.since && segment.since > 0 && (
+          {segment.since != null && segment.since > 0 && (
             <span className="ml-1 text-muted-foreground text-[10px]">
               since {format(new Date(segment!.since * 1000), 'MMM d, yyyy')}
             </span>
@@ -301,7 +301,7 @@ export default function UpcomingCampaigns() {
               )}
             >
               {segmentMap.get(baseSegment.id) || baseSegment.id}
-              {baseSegment.since && baseSegment.since > 0 && (
+              {baseSegment.since != null && baseSegment.since > 0 && (
                 <span className="ml-1 text-muted-foreground text-[10px]">
                   since{' '}
                   {format(new Date(baseSegment.since * 1000), 'MMM d, yyyy')}
@@ -313,7 +313,7 @@ export default function UpcomingCampaigns() {
                   {filters.map((filter, idx) => (
                     <span key={idx} className="mr-1">
                       {segmentMap.get(filter.id) || filter.id}
-                      {filter.since && filter.since > 0 && (
+                      {filter.since != null && filter.since > 0 && (
                         <span className="ml-1 text-muted-foreground text-[10px]">
                           since{' '}
                           {format(new Date(filter.since * 1000), 'MMM d, yyyy')}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes condition in `UpcomingCampaigns.tsx` to handle null/undefined values for `segment.since`, `baseSegment.since`, and `filter.since`.
> 
>   - **Behavior**:
>     - Fixes condition in `UpcomingCampaigns.tsx` to handle `null` or `undefined` values for `segment.since`, `baseSegment.since`, and `filter.since`.
>     - Ensures 'since' date is displayed only when value is not `null` or `undefined` and greater than zero.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PublicDataWorks%2Ftxt-outlier-frontend&utm_source=github&utm_medium=referral)<sup> for 9e5a199922eea35379ec253eb8cb00ac86993080. You can [customize](https://app.ellipsis.dev/PublicDataWorks/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of “since” timestamps in Upcoming Campaigns, ensuring badges render consistently only when valid and positive.
- Chores
  - Minor internal logic cleanup to make timestamp checks more explicit without altering date formatting or public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->